### PR TITLE
fix(bin/zip.js): add ignore file for zip

### DIFF
--- a/bin/zip.js
+++ b/bin/zip.js
@@ -6,7 +6,8 @@ const glob = require('glob')
 const releaseDir = path.join(__dirname, '../release')
 
 const zipDirList = glob.sync('*', {
-  cwd: releaseDir
+  cwd: releaseDir,
+  ignore: '*.zip'
 })
 
 function zip(source, target) {
@@ -48,7 +49,10 @@ function zip(source, target) {
   archive.pipe(output)
 
   // append files from a sub-directory, putting its contents at the root of archive
-  archive.directory(source, false)
+  archive.glob('**', {
+    cwd: source,
+    ignore: ['node_modules/**', 'dist/**', '.nuxt/**']
+  })
 
   // finalize the archive (ie we are done appending files but streams have to finish yet)
   // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand


### PR DESCRIPTION
A new feature 

**EXCLUDE**
- node_modules
- .nuxt
- dist

## Why
If release files were cached, some unnecessary files will zip in together

- before this change, the dir with node_modules will zipped with 59905057 bytes

## How
archiver with glob and add an ignore options

## Test
**AFTER**
![image](https://user-images.githubusercontent.com/27187946/59757947-6b699080-92bf-11e9-82ee-fa5bf7441809.png)

**BEFORE**
![image](https://user-images.githubusercontent.com/27187946/59758241-11b59600-92c0-11e9-90f3-1917759c7097.png)



