### PR TITLE
fix: 鼠标移入头像或名字无法显示下拉框

### DIFF
--- a/template/frameworks/multiple/components/layout-head.vue
+++ b/template/frameworks/multiple/components/layout-head.vue
@@ -22,14 +22,14 @@
         </ul>
       </div>
       <div class="head-right">
-        <div class="head-active">
-          <img :src="userImg" class="userName-Img" alt="userName-Img" />
-        </div>
-        <!-- 用户名称 -->
-        <div class="userName-text">{{ userName }}</div>
         <el-dropdown placement="bottom-end" @command="exitBtn">
           <span class="el-dropdown-link">
-            <i class="el-icon-arrow-down el-icon--right set-Iconcolor"></i>
+            <div class="head-active">
+              <img :src="userImg" class="userName-img" alt="userName-img" />
+            </div>
+            <!-- 用户名称 -->
+            <div class="userName-text">{{ userName }}</div>
+            <i class="el-icon-arrow-down el-icon--right set-iconcolor"></i>
           </span>
           <el-dropdown-menu slot="dropdown" class="user-drop-menu">
             <el-dropdown-item
@@ -206,28 +206,29 @@ export default {
     display: flex;
     align-items: center;
 
-    div {
-      display: inline-block;
-    }
-
-    .set-Iconcolor {
+    .set-iconcolor {
       color: @headMenu;
     }
 
-    .head-active {
-      .userName-Img {
-        width: 30px;
-        height: 30px;
-        border-radius: 50%;
+    .el-dropdown-link {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      .head-active {
+        .userName-img {
+          width: 30px;
+          height: 30px;
+          border-radius: 50%;
+          margin-right: 10px;
+        }
+      }
+
+      .userName-text {
+        text-align: center;
+        overflow: hidden;
+        color: #fff;
         margin-right: 10px;
       }
-    }
-
-    .userName-text {
-      text-align: center;
-      overflow: hidden;
-      color: #fff;
-      margin-right: 10px;
     }
 
     .head-search {

--- a/template/frameworks/multiple/components/layout-head.vue
+++ b/template/frameworks/multiple/components/layout-head.vue
@@ -25,10 +25,10 @@
         <el-dropdown placement="bottom-end" @command="exitBtn">
           <span class="el-dropdown-link">
             <div class="head-active">
-              <img :src="userImg" class="userName-img" alt="userName-img" />
+              <img :src="userImg" class="username-img" alt="username-img" />
             </div>
             <!-- 用户名称 -->
-            <div class="userName-text">{{ userName }}</div>
+            <div class="username-text">{{ userName }}</div>
             <i class="el-icon-arrow-down el-icon--right set-iconcolor"></i>
           </span>
           <el-dropdown-menu slot="dropdown" class="user-drop-menu">
@@ -215,7 +215,7 @@ export default {
       align-items: center;
       cursor: pointer;
       .head-active {
-        .userName-img {
+        .username-img {
           width: 30px;
           height: 30px;
           border-radius: 50%;
@@ -223,7 +223,7 @@ export default {
         }
       }
 
-      .userName-text {
+      .username-text {
         text-align: center;
         overflow: hidden;
         color: #fff;

--- a/template/frameworks/single/layouts/default.vue
+++ b/template/frameworks/single/layouts/default.vue
@@ -39,13 +39,13 @@
       <div class="header-wrap">
         <el-row class="head-container" type="flex" justify="end" align="middle">
           <div class="head-right">
-            <div class="head-active">
-              <img :src="userImg" class="userName-Img" alt="userName-Img" />
-            </div>
-            <!-- 用户名称 -->
-            <div class="userName-text">{{ $store.state.user.nickname }}</div>
             <el-dropdown placement="bottom-end" @command="exitBtn">
               <span class="el-dropdown-link">
+                <div class="head-active">
+                  <img :src="userImg" class="userName-img" alt="userName-img" />
+                </div>
+                <!-- 用户名称 -->
+                <div class="userName-text">{{ $store.state.user.nickname }}</div>
                 <i class="el-icon-arrow-down el-icon--right set-Iconcolor"></i>
               </span>
               <el-dropdown-menu slot="dropdown" class="user-drop-menu">
@@ -137,26 +137,26 @@ export default {
 
     .head-right {
       margin-right: 10px;
-      display: flex;
-      align-items: center;
 
-      div {
-        display: inline-block;
-      }
+      .el-dropdown-link {
+        display: flex;
+        align-items: center;
 
-      .head-active {
-        .userName-Img {
-          width: 30px;
-          height: 30px;
-          border-radius: 50%;
-          margin: 0 15px;
+        .head-active {
+          .userName-img {
+            width: 30px;
+            height: 30px;
+            border-radius: 50%;
+            margin: 0 15px;
+          }
         }
-      }
 
-      .userName-text {
-        text-align: center;
-        overflow: hidden;
-        margin-right: 10px;
+        .userName-text {
+          text-align: center;
+          overflow: hidden;
+          margin-right: 10px;
+          color: rgba(0, 0, 0, 0.65);
+        }
       }
 
       .head-search {

--- a/template/frameworks/single/layouts/default.vue
+++ b/template/frameworks/single/layouts/default.vue
@@ -42,10 +42,10 @@
             <el-dropdown placement="bottom-end" @command="exitBtn">
               <span class="el-dropdown-link">
                 <div class="head-active">
-                  <img :src="userImg" class="userName-img" alt="userName-img" />
+                  <img :src="userImg" class="username-img" alt="username-img" />
                 </div>
                 <!-- 用户名称 -->
-                <div class="userName-text">{{ $store.state.user.nickname }}</div>
+                <div class="username-text">{{ $store.state.user.nickname }}</div>
                 <i class="el-icon-arrow-down el-icon--right set-Iconcolor"></i>
               </span>
               <el-dropdown-menu slot="dropdown" class="user-drop-menu">
@@ -143,7 +143,7 @@ export default {
         align-items: center;
 
         .head-active {
-          .userName-img {
+          .username-img {
             width: 30px;
             height: 30px;
             border-radius: 50%;
@@ -151,7 +151,7 @@ export default {
           }
         }
 
-        .userName-text {
+        .username-text {
           text-align: center;
           overflow: hidden;
           margin-right: 10px;


### PR DESCRIPTION
close #11 
- fix: 鼠标移入头像和名字无法唤出操作菜单

## Why
箭头太小了，鼠标移入箭头才显示下拉框的话体验不好

## How
1. 把头像和用户名也放进 el-dropdown 里
2. 修改样式

![image](https://user-images.githubusercontent.com/26338853/60082740-f1298800-9766-11e9-88dd-908bb7ce0816.png)

## Test
鼠标移入头像或用户名或箭头显示下拉框

## After
![hover2](https://user-images.githubusercontent.com/26338853/60084875-e8d34c00-976a-11e9-8b96-09f448db652e.gif)

