### PR TITLE
pref: use router.replace instead of location.reload

### DIFF
--- a/template/frameworks/single/store/index.js
+++ b/template/frameworks/single/store/index.js
@@ -35,8 +35,7 @@ export const mutations = {
         path: cookiePath
       })
     })
-    // 清空state，跳转到login页的逻辑交给路由守卫
-    location.reload()
+    this.$router.replace('/login')
   },
 
   update(state, payload) {


### PR DESCRIPTION
## Why
The site delay when location.reload, so use router.replace that doesn't load document again.

## Test
![201903137](https://user-images.githubusercontent.com/27187946/60574954-2d836680-9dad-11e9-9fdb-b66eaf18f838.gif)
