### PR TITLE
fix(nuxt.config): missing target options

### DIFF
--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -16,27 +16,27 @@ let publicPath = process.env.PUBLIC_PATH
 const config = {
   aliIconFont: '',
   env: {
-    <% if (template === 'single') { %>
+    <%_ if (template === 'single') { _%>
     mock: {
       '/deepexi-tenant': mockServer,
       '/deepexi-permission': mockServer
     },
-    dev: {
+    dev: apiServer ? {
       '/deepexi-tenant': apiServer,
       '/deepexi-permission': apiServer
-    }
-    <% } else if (template === 'multiple') { %>
+    } : {}
+    <%_ } else if (template === 'multiple') { _%>
     mock: {
       '/deepexi-dashboard': mockServer,
       '/xpaas-enterprise-contact': mockServer,
       '/xpaas-console-api': mockServer
     },
-    dev: {
+    dev: apiServer ? {
       '/deepexi-dashboard': apiServer,
       '/xpaas-enterprise-contact': apiServer,
       '/xpaas-console-api': apiServer
-    }
-    <% } %>
+    } : {}
+    <%_ } _%>
   }
 }
 


### PR DESCRIPTION
Closes #29

## Why
occur error while yarn dev without apiServer

## How
Describe your steps:
1. if apiServer is undefined, return an empty object for proxy
2. http-proxy-middleware will check options.target if path keys exist
![code3](https://user-images.githubusercontent.com/27187946/60789061-bd038d80-a190-11e9-9c4f-11e48e154a7d.png)


## Test
**before**
![image](https://user-images.githubusercontent.com/27187946/60788935-72821100-a190-11e9-9cfc-ca0730f195ba.png)

**after**
![image](https://user-images.githubusercontent.com/27187946/60789029-acebae00-a190-11e9-818f-f4364bbe4c18.png)

