### PR TITLE
feat: commitlint support

### DIFF
--- a/template/_package.json
+++ b/template/_package.json
@@ -53,6 +53,8 @@
     "nuxt": "^2.7.1"
   },
   "devDependencies": {
+    "@commitlint/cli": "^8.0.0",
+    "@commitlint/config-conventional": "^8.0.0",
     <%_ if (template === 'mobile') { _%>
     "babel-plugin-import": "^1.12.0",
     <%_ } else { _%>
@@ -69,7 +71,7 @@
     "eslint-loader": "^1.7.1",
     "eslint-plugin-vue": "^4.0.0",
     "github-release-notes": "^0.17.0",
-    "husky": "1.3.1",
+    "husky": "^3.0.0",
     "lint-staged": "^8.1.0",
     "prettier": "1.18.2",
     "standard-version": "^6.0.1",
@@ -85,6 +87,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
+      "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
       "post-commit": "git update-index --again"
     }
   },

--- a/template/_package.json
+++ b/template/_package.json
@@ -71,7 +71,7 @@
     "eslint-loader": "^1.7.1",
     "eslint-plugin-vue": "^4.0.0",
     "github-release-notes": "^0.17.0",
-    "husky": "^3.0.0",
+    "husky": "1.3.1",
     "lint-staged": "^8.1.0",
     "prettier": "1.18.2",
     "standard-version": "^6.0.1",

--- a/template/commitlint.config.js
+++ b/template/commitlint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [0, 'always', ['merge']]
+  }
+}


### PR DESCRIPTION
- feat: commitlint support
- hooks commit-msg can use only with husky@1.3.1
- if upgrade husky to latest, commit-msg's value should be "commitlint -E HUSKY_GIT_PARAMS"

**It should git init before npm install to ensure husky hooks works**