### PR TITLE
fix: 刷新页面后，tabbar未高亮对应tab的问题

### DIFF
--- a/template/frameworks/mobile/layouts/layout-with-footer.vue
+++ b/template/frameworks/mobile/layouts/layout-with-footer.vue
@@ -48,6 +48,14 @@ export default {
         }
       ]
     }
+  },
+  watch: {
+    $route: {
+      handler({path}) {
+        this.active = this.footerTab.findIndex(e => e.url === path)
+      },
+      immediate: true
+    }
   }
 }
 </script>

--- a/template/frameworks/mobile/pages/order-list.vue
+++ b/template/frameworks/mobile/pages/order-list.vue
@@ -15,6 +15,7 @@
 import DataList from '@femessage/data-list'
 
 export default {
+  layout: 'layout-with-footer',
   components: {
     DataList
   },


### PR DESCRIPTION
## Why
刷新页面后，tabbar未高亮对应tab的问题

## How
在`layout-with-footer.vue`中watch $route变化，并更新tabbar。参考了秀域的实现

## Test
刷新页面和从非tabbar处进入购物车，tabbar能高亮购物车按钮
![tabbar](https://user-images.githubusercontent.com/19591950/62519483-3d83df80-b85e-11e9-9a7b-27d3b9f5b70a.gif)


