### PR TITLE
fix: 通过提示语创建项目会丢失部分模块

### DIFF
--- a/generator/GeneratorContext.js
+++ b/generator/GeneratorContext.js
@@ -1,5 +1,4 @@
 const spawn = require('cross-spawn')
-const config = require('../template.config')
 
 module.exports = function (BaseGeneratorContext) {
   return class GeneratorContext extends BaseGeneratorContext {
@@ -7,13 +6,8 @@ module.exports = function (BaseGeneratorContext) {
       if (this.sao.opts.mock) {
         return this.sao.opts.mock.answers
       }
-      const { answers = {} } = this
-      const template = config.find(t => t.template === answers.template)
-      if (template) {
-        delete template.folder
-        Object.assign(this.sao.opts.config, template)
-      }
-      return Object.assign(this.sao.opts.config, answers)
+      const answer = this.answers || {}
+      return Object.assign(this.sao.opts.config, answer)
     }
 
     get outDir() {

--- a/generator/GeneratorContext.js
+++ b/generator/GeneratorContext.js
@@ -1,4 +1,5 @@
 const spawn = require('cross-spawn')
+const config = require('../template.config')
 
 module.exports = function (BaseGeneratorContext) {
   return class GeneratorContext extends BaseGeneratorContext {
@@ -6,8 +7,13 @@ module.exports = function (BaseGeneratorContext) {
       if (this.sao.opts.mock) {
         return this.sao.opts.mock.answers
       }
-      const answer = this.answers || {}
-      return Object.assign(this.sao.opts.config, answer)
+      const { answers = {} } = this
+      const template = config.find(t => t.template === answers.template)
+      if (template) {
+        delete template.folder
+        Object.assign(this.sao.opts.config, template)
+      }
+      return Object.assign(this.sao.opts.config, answers)
     }
 
     get outDir() {

--- a/generator/saofile.js
+++ b/generator/saofile.js
@@ -84,7 +84,12 @@ module.exports = {
      * 定义见 template.config.js
      * 这里只用到values；key是为了方便覆盖配置用的
      */
-    Object.values(this.template).forEach((value) => {
+    const configItem = config.find(t => t.template === this.answers.template)
+    const template = {
+      ...configItem,
+      ...this.template
+    }
+    Object.values(template).forEach((value) => {
       actions.push({
         type: 'add',
         files: '**',


### PR DESCRIPTION
## Why
1.5.0版在prompts回答中选择模板时，会丢失大部分config中的公共模块，仅剩余template独有模块和ci模块。比如在问答中选择`template: single; ci: gitlab-ci`，则生成的项目仅包含`template/frameworks/single`&`template/framework/gitlab-ci`
### 为什么1.4.0没有这个问题
在1.4.0版中，最终选取的template实际有两种途径合成：
1. 在命令行指定 `-t [template]`和`-a`时，最终的`template = { ...defaultConfig, ...config }`。其中config是`template.config.js`中的配置
2. 在prompt中选择template时，最终的`template = { ...defaultConfig, ...answers }`

在1.4.0版中，恰好template.config.js中的配置和prompts问题中的选项都是三项，所以表现一致：
- folder （如nuxt-vant
- template （如mobile
- ci （如gitlab-ci

在1.5.0版的重构中，我只考虑到第一种情况，即将defaultConfig从`Template.js`移植到`template.config.js`中，没考虑到第二种情况下，最终的config不会读取`template.config.js`中的配置。

## How
在回答完问题后，在`saofile.js`的`actions`中将`template.config.js`中的对应模板补充到`this.template`中

## Test
### Before
测试线上版
![image](https://user-images.githubusercontent.com/19591950/63017018-b7077780-bec7-11e9-961e-cbcd7696ca18.png)
![image](https://user-images.githubusercontent.com/19591950/63017713-9e985c80-bec9-11e9-8dfd-7a142e3ea642.png)

### After
使用`yarn link`测试本地版
![image](https://user-images.githubusercontent.com/19591950/63017039-cb4b7480-bec7-11e9-8cb7-b9bd8128a9b4.png)
![image](https://user-images.githubusercontent.com/19591950/63017872-02228a00-beca-11e9-8d58-88796185cbf3.png)
