### PR TITLE
feat: active dev source map

### DIFF
--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -101,7 +101,12 @@ module.exports = {
           <%_ } _%>
         ]
       ]
-    }
+    },
+    extend(config, {isDev}) {
+      if (isDev) {
+        config.devtool = '#source-map'
+      }
+    },
   },
   /*
    ** Headers of the page


### PR DESCRIPTION
## Why
Without a source map in development env, debugger will breakpoint at the webpack bundle which is difficult to debug.

## How
Show the code in the changed file.

## Test
**before**
![no-source-map](https://user-images.githubusercontent.com/27187946/65590805-f85a6f00-dfbd-11e9-8c3e-efe8504a30ba.jpg)

**after**
![source-map](https://user-images.githubusercontent.com/27187946/65590826-01e3d700-dfbe-11e9-9a6c-12c84d0de28a.jpg)
