### PR TITLE
fix: mobile模板兼容全面屏

### DIFF
--- a/template/frameworks/mobile/assets/global.less
+++ b/template/frameworks/mobile/assets/global.less
@@ -36,7 +36,7 @@ body {
   height: 120px;
 }
 
-// 安全区适配
+// 安全区适配 (https://www.yuque.com/loyulc/bhqeod/xmidqo)
 .safe-area-inset-bottom {
   padding-bottom: constant(safe-area-inset-bottom);
   padding-bottom: env(safe-area-inset-bottom);

--- a/template/frameworks/mobile/assets/global.less
+++ b/template/frameworks/mobile/assets/global.less
@@ -36,7 +36,7 @@ body {
   height: 120px;
 }
 
-// 安全区适配 (https://www.yuque.com/loyulc/bhqeod/xmidqo)
+// 安全区适配 (https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport/viewport-fit)
 .safe-area-inset-bottom {
   padding-bottom: constant(safe-area-inset-bottom);
   padding-bottom: env(safe-area-inset-bottom);

--- a/template/frameworks/mobile/assets/global.less
+++ b/template/frameworks/mobile/assets/global.less
@@ -1,5 +1,6 @@
 body {
   font-size: 28px;
+  .safe-area-inset-bottom();
 }
 
 .text-center {
@@ -33,4 +34,17 @@ body {
 .fixed-box { // fixed-btn 用relative的父元素站位
   position: relative;
   height: 120px;
+}
+
+// 安全区适配
+.safe-area-inset-bottom {
+  padding-bottom: constant(safe-area-inset-bottom);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+// vant 组件安全区全局适配
+.van-tabbar--fixed,
+.van-goods-action,
+.van-submit-bar,
+.van-popup--bottom {
+  .safe-area-inset-bottom();
 }

--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -127,7 +127,7 @@ module.exports = {
     meta: [
       {charset: 'utf-8'},
       <%_ if (template === 'mobile') { _%>
-      {name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover'},
+      {name: 'viewport', content: 'width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover'},
       <%_ } else { _%>
       {name: 'viewport', content: 'width=device-width, initial-scale=1'},
       <%_ } _%>

--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -126,7 +126,11 @@ module.exports = {
     title: '',
     meta: [
       {charset: 'utf-8'},
+      <%_ if (template === 'mobile') { _%>
+      {name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover'},
+      <%_ } else { _%>
       {name: 'viewport', content: 'width=device-width, initial-scale=1'},
+      <%_ } _%>
       {'http-equiv': 'x-ua-compatible', content: 'IE=edge, chrome=1'},
       {
         hid: 'description',


### PR DESCRIPTION
## Why
全面屏底部自带黑条遮挡底部tab-bar，需兼容处理

## How
fixed定位在底部的tab-bar, 设置padding-bottom值为safe-area-inset-bottom高度的边距兼容全面屏

### 适配前
<img width="180" alt="lADPBE1XYdXYfE_NCYTNBGU_1125_2436 jpg_620x10000q90g" src="https://user-images.githubusercontent.com/42985122/66696131-cf471780-ecfb-11e9-84ac-d4934437ab16.jpg">

### 适配后
<img width="180" alt="lADPBE1XYdXYWinNCYTNBGU_1125_2436 jpg_620x10000q90g" src="https://user-images.githubusercontent.com/42985122/66696118-af175880-ecfb-11e9-9f1b-d72e9bf4f50e.jpg">

