### PR TITLE
fix: prettier rule conflict with stylelint rule

### DIFF
--- a/template/framework/.stylelintrc
+++ b/template/framework/.stylelintrc
@@ -1,6 +1,8 @@
 {
   "extends": "stylelint-config-standard",
   "rules": {
-    "no-empty-source": null
+    "no-empty-source": null，
+    "declaration-colon-newline-after": null,
+    "value-list-comma-newline-after": null
   }
 }


### PR DESCRIPTION
## stylelint 默认规则会修改被 prettier 修改过的规则，常见于 box-shadow 属性中

## Why
stylelint 会修改被 prettier 修改过的 CSS 属性

例如原始CSS如下
```css
box-shadow: inset 0 0 20px #f0f2f5, inset 0 0 20px #f0f2f5, inset 0 0 20px #f0f2f5;
```

prettier 会将其修改为
```css
box-shadow: inset 0 0 20px #f0f2f5, inset 0 0 20px #f0f2f5,
    inset 0 0 20px #f0f2f5;
```

stylelint 会最终将其修改为
```css
box-shadow:
    inset 0 0 20px #f0f2f5,
 inset 0 0 20px #f0f2f5,
    inset 0 0 20px #f0f2f5;
```

## Docs

[declaration-colon-newline-after](https://stylelint.io/user-guide/rules/declaration-colon-newline-after)
[value-list-comma-newline-after](https://stylelint.io/user-guide/rules/value-list-comma-newline-after)