### PR TITLE
fix: wrong full-width comma in stylelintrc

### DIFF
--- a/template/framework/.stylelintrc
+++ b/template/framework/.stylelintrc
@@ -1,7 +1,7 @@
 {
   "extends": "stylelint-config-standard",
   "rules": {
-    "no-empty-source": null，
+    "no-empty-source": null,
     "declaration-colon-newline-after": null,
     "value-list-comma-newline-after": null
   }


### PR DESCRIPTION
## Why
![image](https://user-images.githubusercontent.com/27187946/69950727-db4a9b00-152e-11ea-813a-8b485c86a91f.png)

