### PR TITLE
fix: 修复自适应计算出错的 bug

### DIFF
--- a/template/framework-mobile/postcss.config.js
+++ b/template/framework-mobile/postcss.config.js
@@ -8,7 +8,11 @@ module.exports = ({file}) => {
    * 使vant组件代码自适应viewport。引入其他第三方样式库时可参考此方式处理
    * @see https://github.com/youzan/vant/issues/1181
    */
-  if (file && file.dirname && file.dirname.indexOf('vant') > -1) {
+  if (
+    file &&
+    file.dirname &&
+    /node_modules\/\@femessage\/vant/.test(file.dirname)
+  ) {
     vwUnit = 375
   }
   return {

--- a/template/framework-mobile/postcss.config.js
+++ b/template/framework-mobile/postcss.config.js
@@ -11,7 +11,7 @@ module.exports = ({file}) => {
   if (
     file &&
     file.dirname &&
-    /node_modules\/\@femessage\/vant/.test(file.dirname)
+    /node_modules\/@femessage\/vant/.test(file.dirname)
   ) {
     vwUnit = 375
   }


### PR DESCRIPTION
## Why
原判断是路径中有`vant`就用 375 的屏幕宽度。但如果项目名称就包含`vant`，如默认模板名称`nuxt-vant`，则整个项目都错配了屏幕宽度（普通应该是 750 的屏幕宽

## Test
### Before
![image](https://user-images.githubusercontent.com/19591950/70120754-3eac0880-16a8-11ea-8eb3-f529740011c9.png)


### After
![image](https://user-images.githubusercontent.com/19591950/70120636-0a384c80-16a8-11ea-91d7-55064b84a32c.png)
