### PR TITLE
chore: only run lhci on dev branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 script:
   - yarn test
   - yarn generate
+  # https://stackoverflow.com/questions/37544306/travis-different-script-for-different-branch
   - test "$TRAVIS_BRANCH" = "dev" && ./lhci.sh
   - test "$TRAVIS_BRANCH" = "master" &&  yarn zip
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
   only:
     - master
+    - dev
 language: node_js
 node_js:
 - lts/*
@@ -8,12 +9,11 @@ git:
   depth: 15
 install:
 - yarn --frozen-lockfile
-- yarn global add @lhci/cli
 script:
   - yarn test
-  - yarn build:release
-  - yarn deploy
-  - lhci autorun --upload.target=temporary-public-storage --collect.staticDistDir=./dist --collect.url=http://localhost/nuxt-element-dashboard --collect.url=http://localhost/nuxt-multiple-spa --collect.url=http://localhost/nuxt-vant
+  - yarn generate
+  - test "$TRAVIS_BRANCH" = "dev" && ./lhci.sh
+  - test "$TRAVIS_BRANCH" = "master" &&  yarn zip
 addons:
   chrome: stable
 cache: 
@@ -32,5 +32,7 @@ deploy:
   - provider: script
     skip_cleanup: true
     script: npx semantic-release
+    on:
+      branch: master
 after_script:
   - ./notify.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ script:
   - yarn test
   - yarn generate
   # https://stackoverflow.com/questions/37544306/travis-different-script-for-different-branch
-  - test "$TRAVIS_BRANCH" = "dev" && yarn build && ./lhci.sh
-  - test "$TRAVIS_BRANCH" = "master" &&  yarn zip
+  - test "$TRAVIS_BRANCH" = "dev" && yarn build && ./lhci.sh || echo skip
+  - test "$TRAVIS_BRANCH" = "master" &&  yarn zip || echo skip
 addons:
   chrome: stable
 cache: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - yarn test
   - yarn generate
   # https://stackoverflow.com/questions/37544306/travis-different-script-for-different-branch
-  - test "$TRAVIS_BRANCH" = "dev" && ./lhci.sh
+  - test "$TRAVIS_BRANCH" = "dev" && yarn build && ./lhci.sh
   - test "$TRAVIS_BRANCH" = "master" &&  yarn zip
 addons:
   chrome: stable

--- a/lhci.sh
+++ b/lhci.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ "$TRAVIS_BRANCH" != "dev" ]
+then
+  echo "do not run lhci cause not on dev branch"
+  exit 0
+fi
+
+yarn global add @lhci/cli
+
+lhci autorun --upload.target=temporary-public-storage --collect.staticDistDir=./dist --collect.url=http://localhost/nuxt-element-dashboard --collect.url=http://localhost/nuxt-multiple-spa --collect.url=http://localhost/nuxt-vant

--- a/lhci.sh
+++ b/lhci.sh
@@ -1,10 +1,4 @@
 #!/bin/sh
-if [ "$TRAVIS_BRANCH" != "dev" ]
-then
-  echo "do not run lhci cause not on dev branch"
-  exit 0
-fi
-
 yarn global add @lhci/cli
 
 lhci autorun --upload.target=temporary-public-storage --collect.staticDistDir=./dist --collect.url=http://localhost/nuxt-element-dashboard --collect.url=http://localhost/nuxt-multiple-spa --collect.url=http://localhost/nuxt-vant

--- a/notify.sh
+++ b/notify.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+if [ "$TRAVIS_BRANCH" != "master" ]
+then
+  echo "do not notify cause not on master branch"
+  exit 0
+fi
+
 if [ "$TRAVIS_TEST_RESULT" != "0" ]
 then
   echo "build not success, bye"

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "lint": "eslint ./",
     "test": "ava test --verbose",
     "test:snapshot": "ava test --verbose --update-snapshots",
-    "build": "node bin/cli.js -a -o release",
-    "build:release": "node bin/cli.js -a -o release && node bin/zip.js",
-    "deploy": "yarn build && node bin/deploy/build.js",
+    "generate": "node bin/cli.js -a -o release",
+    "zip": "node bin/zip.js",
+    "build": "node bin/deploy/build.js",
     "release": "gren release --override"
   },
   "dependencies": {


### PR DESCRIPTION
## Why
Described as title

## How
Using env var TRAVIS_BRANCH

## Test
<strike>No, hope this can run fine🙏</strike>

This is tricky, but I worked it through
```sh
script:
- test "$TRAVIS_BRANCH" = "dev" && yarn build && ./lhci.sh || echo skip
- test "$TRAVIS_BRANCH" = "master" && yarn zip || echo skip
```

## Docs
See .travis.yml comment

## Besides
Netlify has already modified
