### PR TITLE
fix: windows 下主显示容器宽度变宽

### DIFF
--- a/template/framework-admin/components/breadcrumb/bread-data.js
+++ b/template/framework-admin/components/breadcrumb/bread-data.js
@@ -2,7 +2,7 @@ const HOME = {name: '首页'}
 const ACCOUNT = {name: '账户管理', disabled: true}
 const FIELD = {name: '字段管理'}
 const GROUP = {name: '群组管理'}
-const ORGANNIZATION = {name: '组织管理'}
+const ORGANIZATION = {name: '组织管理'}
 const POSITION = {name: '职位管理'}
 const STAFF = {name: '员工管理'}
 
@@ -21,7 +21,7 @@ export default [
   },
   {
     name: 'account-organization',
-    breadcrumb: [ACCOUNT, ORGANNIZATION],
+    breadcrumb: [ACCOUNT, ORGANIZATION],
   },
   {
     name: 'account-position',

--- a/template/framework-admin/layouts/default.vue
+++ b/template/framework-admin/layouts/default.vue
@@ -100,7 +100,7 @@ export default {
   }
 
   .sub-content {
-    // overflow-y: auto;
+    width: calc(100vw - @sidebar-width);
     height: calc(100vh - @--header-height - @--breadcrumb-height);
   }
 


### PR DESCRIPTION
## Why
在 windows 下 el-scrollbar 会增加 -17px 的 margin 去遮盖 windows 的滚动条。导致子容器宽度变宽。

## How
将需要滚动的子容器宽度设置为定宽

## Test
Before
![image](https://user-images.githubusercontent.com/27187946/74825178-71c77500-5344-11ea-992d-e2d3c49fddb0.png)

After
![image](https://user-images.githubusercontent.com/27187946/74825212-81df5480-5344-11ea-8e04-1dc887a60e8d.png)
